### PR TITLE
Update branch name for Google Benchmark

### DIFF
--- a/src/cmake/GoogleBenchmark.cmake
+++ b/src/cmake/GoogleBenchmark.cmake
@@ -6,7 +6,7 @@ include(FetchContent)
 FetchContent_Declare(
     googlebenchmark
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG origin/master
+    GIT_TAG origin/main
 )
 
 FetchContent_MakeAvailable(googlebenchmark)


### PR DESCRIPTION
* cmake/GoogleBenchmark.cmake 
  * Update GIT_TAG in FetchContent_Declare to `origin/main`